### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/fjtdg/8e7df17d-2ee9-4772-8b11-99d38ba4aece/0b12a572-4783-48ce-96de-584f72fd32ed/_apis/work/boardbadge/1dfc91e5-49e1-43e9-80ee-dfcfc35d014f)](https://dev.azure.com/fjtdg/8e7df17d-2ee9-4772-8b11-99d38ba4aece/_boards/board/t/0b12a572-4783-48ce-96de-584f72fd32ed/Microsoft.RequirementCategory)
 # mcweb
 Rudimentary web interface for minecraft server
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#13](https://dev.azure.com/fjtdg/8e7df17d-2ee9-4772-8b11-99d38ba4aece/_workitems/edit/13). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.